### PR TITLE
Update README and dependency script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The non-OpenCV CUDA support part has been tested and verified on the following O
 - `3.4.3` 
 - `4.0.1`
 - `4.1.1`
+- `4.1.2`
   
 ### Hardware Prerequisites
 - __Camera__: any Leopard USB3.0/2.0 cameras
@@ -112,7 +113,7 @@ foo@bar:~$ ls /dev//vi* ## list all the video device in your host PC
 ### Dependencies
 Make sure the libraries have installed. Run [configure.sh](configure.sh) in current directory for completing installing all the required dependencies.
 ```sh
-$ chmod +X configure.sh
+$ chmod +x configure.sh
 $ ./configure.sh
 ```
 

--- a/configure.sh
+++ b/configure.sh
@@ -8,4 +8,4 @@ sudo apt-get -y install v4l-utils libv4l-dev                #for v4l2
 sudo apt-get -y install libudev-dev                         #for udev
 sudo apt-get -y install libopencv-dev                       #for opencv dependencies
 sudo apt-get -y install libjson-c-dev                       #for json parser
-sudo apt-get -y install libpng12-dev                        #for capturing png
+sudo apt-get -y install libpng-dev                          #for capturing png


### PR DESCRIPTION
Two modifications:
- Update `configure.sh` script with obsolete binary package name to avoid error on newer version of linux
- It works with OpenCV `4.1.2` version, so add that to support version list 
- Update chmod instruction to make it work with all kind of user environment